### PR TITLE
Improve merge commit messages

### DIFF
--- a/dist/create-pr/index.js
+++ b/dist/create-pr/index.js
@@ -25586,7 +25586,7 @@ ${formattedCommitList}
   <summary><h2>Resolving conflicts</h2></summary>
   To resolve any conflicts, check out the temporary branch and run the following command:
 
-    git merge ${baseName}
+    git merge ${baseName} -m "Resolve conflicts in ${baseName}"
 </details>
 
 <details>
@@ -25594,7 +25594,7 @@ ${formattedCommitList}
   To ignore from the remote branch, first reset the temporary branch to ${baseName} and manually merge using the \`ours\` merge strategy:
 
     git reset --hard ${baseName}
-    git merge --strategy=ours ${branchName}
+    git merge --strategy=ours ${branchName} -m "Ignore changes from ${branchName}"
 
   Then, push the temporary branch to upate the pull request.
 </details>`;
@@ -25622,13 +25622,15 @@ async function hasNewCommits(branchName, baseName) {
     const regex = new RegExp(`${escapedRegex}$`, 'm');
     return !regex.test(output.stdout);
 }
-async function enableAutoMerge(pullRequestId) {
+async function enableAutoMerge(pullRequestId, branchName, baseName) {
     await exec.exec('gh', [
         'pr',
         'merge',
         pullRequestId.toString(),
+        '--subject',
+        `Merge ${branchName} into ${baseName} (#${pullRequestId})`,
         '--auto', // Enable auto-merge
-        '-m' // Use merge commit strategy
+        '--merge' // Use merge commit strategy
     ]);
 }
 async function getCommitList(branchName, baseName) {
@@ -25834,7 +25836,7 @@ async function createMergeUpPullRequest() {
         }
         // Enable auto-merge if requested
         if (inputs.enableAutoMerge) {
-            await core.group('Enable auto-merge', async () => git.enableAutoMerge(pullRequest.id));
+            await core.group('Enable auto-merge', async () => git.enableAutoMerge(pullRequest.id, inputs.currentBranch, nextBranchName));
         }
         core.setOutput('pullRequestUrl', pullRequest.url);
         core.setOutput('branchName', newBranchName);

--- a/dist/get-next-branch/index.js
+++ b/dist/get-next-branch/index.js
@@ -25586,7 +25586,7 @@ ${formattedCommitList}
   <summary><h2>Resolving conflicts</h2></summary>
   To resolve any conflicts, check out the temporary branch and run the following command:
 
-    git merge ${baseName}
+    git merge ${baseName} -m "Resolve conflicts in ${baseName}"
 </details>
 
 <details>
@@ -25594,7 +25594,7 @@ ${formattedCommitList}
   To ignore from the remote branch, first reset the temporary branch to ${baseName} and manually merge using the \`ours\` merge strategy:
 
     git reset --hard ${baseName}
-    git merge --strategy=ours ${branchName}
+    git merge --strategy=ours ${branchName} -m "Ignore changes from ${branchName}"
 
   Then, push the temporary branch to upate the pull request.
 </details>`;
@@ -25622,13 +25622,15 @@ async function hasNewCommits(branchName, baseName) {
     const regex = new RegExp(`${escapedRegex}$`, 'm');
     return !regex.test(output.stdout);
 }
-async function enableAutoMerge(pullRequestId) {
+async function enableAutoMerge(pullRequestId, branchName, baseName) {
     await exec.exec('gh', [
         'pr',
         'merge',
         pullRequestId.toString(),
+        '--subject',
+        `Merge ${branchName} into ${baseName} (#${pullRequestId})`,
         '--auto', // Enable auto-merge
-        '-m' // Use merge commit strategy
+        '--merge' // Use merge commit strategy
     ]);
 }
 async function getCommitList(branchName, baseName) {
@@ -25834,7 +25836,7 @@ async function createMergeUpPullRequest() {
         }
         // Enable auto-merge if requested
         if (inputs.enableAutoMerge) {
-            await core.group('Enable auto-merge', async () => git.enableAutoMerge(pullRequest.id));
+            await core.group('Enable auto-merge', async () => git.enableAutoMerge(pullRequest.id, inputs.currentBranch, nextBranchName));
         }
         core.setOutput('pullRequestUrl', pullRequest.url);
         core.setOutput('branchName', newBranchName);

--- a/src/git.ts
+++ b/src/git.ts
@@ -52,7 +52,7 @@ ${formattedCommitList}
   <summary><h2>Resolving conflicts</h2></summary>
   To resolve any conflicts, check out the temporary branch and run the following command:
 
-    git merge ${baseName}
+    git merge ${baseName} -m "Resolve conflicts in ${baseName}"
 </details>
 
 <details>
@@ -60,7 +60,7 @@ ${formattedCommitList}
   To ignore from the remote branch, first reset the temporary branch to ${baseName} and manually merge using the \`ours\` merge strategy:
 
     git reset --hard ${baseName}
-    git merge --strategy=ours ${branchName}
+    git merge --strategy=ours ${branchName} -m "Ignore changes from ${branchName}"
 
   Then, push the temporary branch to upate the pull request.
 </details>`
@@ -107,13 +107,19 @@ export async function hasNewCommits(
   return !regex.test(output.stdout)
 }
 
-export async function enableAutoMerge(pullRequestId: number): Promise<void> {
+export async function enableAutoMerge(
+  pullRequestId: number,
+  branchName: string,
+  baseName: string
+): Promise<void> {
   await exec.exec('gh', [
     'pr',
     'merge',
     pullRequestId.toString(),
+    '--subject',
+    `Merge ${branchName} into ${baseName} (#${pullRequestId})`,
     '--auto', // Enable auto-merge
-    '-m' // Use merge commit strategy
+    '--merge' // Use merge commit strategy
   ])
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -80,7 +80,11 @@ export async function createMergeUpPullRequest(): Promise<void> {
     // Enable auto-merge if requested
     if (inputs.enableAutoMerge) {
       await core.group('Enable auto-merge', async () =>
-        git.enableAutoMerge(pullRequest.id)
+        git.enableAutoMerge(
+          pullRequest.id,
+          inputs.currentBranch,
+          nextBranchName
+        )
       )
     }
 


### PR DESCRIPTION
This PR improves the commit messages used for various merges happening:
* The instructions on resolving conflicts now include a message: "Resolve conflicts in <branch-to-merge>"
* The instructions on ignoring changes now include a message: "Ignore changes from <branch-to-merge>"
* The auto-merge now uses a message: "Merge <branch-to-merge> into <base> (<pr-reference)"

This should help clean up commit messages in more complex scenarios, e.g. when conflicts are involved or changes are ignored. Previous messages could get unreadable, as they would include the temporary branch name which isn't really human-friendly.

// cc @prestonvasquez